### PR TITLE
Update to allow Apple Watch access

### DIFF
--- a/keychain/TegKeychain.swift
+++ b/keychain/TegKeychain.swift
@@ -15,7 +15,8 @@ public class TegKeychain {
     let query = [
       TegKeychainConstants.klass       : TegKeychainConstants.classGenericPassword,
       TegKeychainConstants.attrAccount : key,
-      TegKeychainConstants.valueData   : value ]
+      TegKeychainConstants.valueData   : value,
+      TegKeychainConstants.accesibility: kSecAttrAccessibleAfterFirstUnlock  ]
     
     SecItemDelete(query as CFDictionaryRef)
     

--- a/keychain/TegKeychainConstants.swift
+++ b/keychain/TegKeychainConstants.swift
@@ -8,6 +8,7 @@ struct TegKeychainConstants {
   static var valueData: String { return toString(kSecValueData) }
   static var returnData: String { return toString(kSecReturnData) }
   static var matchLimit: String { return toString(kSecMatchLimit) }
+  static var accesibility: String { return toString(kSecAttrAccessible) }
 
   private static func toString(value: CFStringRef) -> String {
     return (value as? String) ?? ""


### PR DESCRIPTION
The default kSecAttrAccesible doesn’t allow the Apple Watch access to the Keychain. Setting  kSecAttrAccesible to kSecAttrAccessibleAfterFirstUnlock allows it to access the keychain.